### PR TITLE
change position of m_useEdtPreamble in initialization

### DIFF
--- a/model/epc-x2.cc
+++ b/model/epc-x2.cc
@@ -280,7 +280,7 @@ EpcX2::RecvFromX2cSocket (Ptr<Socket> socket)
 
           NS_LOG_INFO ("X2 LoadInformation header: " << x2LoadInfoHeader);
 
-          EpcX2SapUser::LoadInformationParams params;
+          EpcX2SapUser::LoadInformationParams params = {};
           params.cellInformationList = x2LoadInfoHeader.GetCellInformationList ();
 
           NS_LOG_LOGIC ("cellInformationList size = " << params.cellInformationList.size ());

--- a/model/eps-bearer-tag.cc
+++ b/model/eps-bearer-tag.cc
@@ -61,6 +61,14 @@ EpsBearerTag::EpsBearerTag ()
     m_bid (0)
 {
 }
+
+EpsBearerTag::EpsBearerTag (uint16_t rnti, uint8_t bid)
+  : m_rnti (rnti),
+    m_bid (bid)
+{
+}
+
+// TODO: this initializer does not use `imsi`
 EpsBearerTag::EpsBearerTag (uint16_t rnti, uint8_t bid, uint64_t imsi)
   : m_rnti (rnti),
     m_bid (bid)

--- a/model/lte-enb-mac.cc
+++ b/model/lte-enb-mac.cc
@@ -741,7 +741,7 @@ LteEnbMac::CheckIfPreambleWasReceived (NbIotRrcSap::NprachParametersNb ce, bool 
             { // sanity check. Actually should be always equal
 
               //NS_BUILD_DEBUG (std::cout << "Preamble received of offset " << int (subcarrierOffset) << " at Subframe " << (10 * (m_frameNo - 1) + (m_subframeNo - 1)) << std::endl);
-              NbIotRrcSap::Rar rar;
+              NbIotRrcSap::Rar rar = {};
               rar.cellRnti = m_cmacSapUser->AllocateTemporaryCellRnti ();
               rar.rapId = subcarrierOffset + iter->first;
               rar.rarPayload.cellRnti = rar.cellRnti;

--- a/model/lte-ffr-distributed-algorithm.cc
+++ b/model/lte-ffr-distributed-algorithm.cc
@@ -623,7 +623,7 @@ LteFfrDistributedAlgorithm::SendLoadInformation (uint16_t targetCellId)
 
   std::vector<EpcX2Sap::UlInterferenceOverloadIndicationItem> m_currentUlInterferenceOverloadIndicationList;
   std::vector <EpcX2Sap::UlHighInterferenceInformationItem>  m_currentUlHighInterferenceInformationList;
-  EpcX2Sap::RelativeNarrowbandTxBand m_currentRelativeNarrowbandTxBand;
+  EpcX2Sap::RelativeNarrowbandTxBand m_currentRelativeNarrowbandTxBand = {};
 
   m_currentRelativeNarrowbandTxBand.rntpPerPrbList = m_dlEdgeRbgMap;
 

--- a/model/lte-ue-mac.cc
+++ b/model/lte-ue-mac.cc
@@ -834,7 +834,7 @@ LteUeMac::RaResponseTimeoutNb (bool contention)
       NbIotRrcSap::ConvertMaxNumPreambleAttemptCE2int (m_CeLevel)) // Max. number of retries in this CE level reached
         {
           m_preambleTransmissionCounterCe = 0;
-          NbIotRrcSap::NprachParametersNbR14 tmp; // needed if EDT is enabled
+          NbIotRrcSap::NprachParametersNbR14 tmp = {}; // needed if EDT is enabled
 
           if (m_CeLevel.coverageEnhancementLevel == m_radioResourceConfig.nprachConfig.nprachParametersList.nprachParametersNb0.coverageEnhancementLevel) // CE0
             {
@@ -934,7 +934,7 @@ LteUeMac::DoStartRandomAccessProcedureNb (bool edt)
   double rsrp = m_uePhySapProvider->GetRSRP ();
   //NS_BUILD_DEBUG (std::cout << "RSRP: " << rsrp << "dBm" << std::endl);
 
-  NbIotRrcSap::NprachParametersNbR14 tmp; // needed if EDT is enabled
+  NbIotRrcSap::NprachParametersNbR14 tmp = {}; // needed if EDT is enabled
 
   if (rsrp <= m_radioResourceConfig.nprachConfig.rsrpThresholdsPrachInfoList.ce2_lowerbound)
     {

--- a/model/lte-ue-phy.cc
+++ b/model/lte-ue-phy.cc
@@ -873,7 +873,7 @@ LteUePhy::CreateDlCqiFeedbackMessage (const SpectrumValue& sinr)
 
   // CREATE DlCqiLteControlMessage
   Ptr<DlCqiLteControlMessage> msg = Create<DlCqiLteControlMessage> ();
-  CqiListElement_s dlcqi;
+  CqiListElement_s dlcqi = {};
 
   dlcqi.m_rnti = m_rnti;
   dlcqi.m_ri = 1; // not yet used

--- a/model/lte-ue-rrc.cc
+++ b/model/lte-ue-rrc.cc
@@ -179,9 +179,9 @@ LteUeRrc::LteUeRrc ()
     m_previousCellId (0),
     m_connEstFailCountLimit (0),
     m_connEstFailCount (0),
+    m_useEdtPreamble(false),
     m_t3412(Days(5)),
     m_t3324(MilliSeconds(3500)),
-    m_useEdtPreamble(false),
     m_numberOfComponentCarriers (MIN_NO_CC),
     m_energyModel(NbiotEnergyModel(BG96(),0))
 {

--- a/model/nb-iot-scheduler.cc
+++ b/model/nb-iot-scheduler.cc
@@ -811,7 +811,7 @@ NbiotScheduler::GetNextAvailableMsg3UlGrantCandidate (uint64_t endSubframeMsg2,
               CheckforNContiniousSubframesUl (subframesOccupied, candidate, numSubframes, j);
           if (subframesOccupied.size () > 0)
             {
-              NbIotRrcSap::UlGrant ret;
+              NbIotRrcSap::UlGrant ret = {};
               ret.schedulingDelay = i;
               ret.msg3Repetitions = NbIotRrcSap::UlGrant::Msg3Repetitions::r4;
               ret.subcarrierIndication = j;
@@ -822,7 +822,7 @@ NbiotScheduler::GetNextAvailableMsg3UlGrantCandidate (uint64_t endSubframeMsg2,
             }
         }
     }
-  NbIotRrcSap::UlGrant ret;
+  NbIotRrcSap::UlGrant ret = {};
   ret.success = false;
   return std::make_pair (ret, std::make_pair (uint64_t (), std::vector<uint64_t> ()));
 }


### PR DESCRIPTION
to get rid of error: 'ns3::LteUeRcc::m_t3324' will be initialized after due to -Wreorder