### PR TITLE
create EpsBearerTag (uint16_t  rnti, uint8_t bid);

### DIFF
--- a/model/eps-bearer-tag.h
+++ b/model/eps-bearer-tag.h
@@ -57,8 +57,17 @@ public:
    * @param rnti the value of the RNTI to set
    * @param bid the value of the Bearer Id to set
    */
-  EpsBearerTag (uint16_t  rnti, uint8_t bid, uint64_t imsi);
+   EpsBearerTag (uint16_t  rnti, uint8_t bid);
   
+  /**
+   * Create a EpsBearerTag with the given RNTI and bearer id
+   *
+   * @param rnti the value of the RNTI to set
+   * @param bid the value of the Bearer Id to set
+   * @param imsi the value of the IMSI to set
+   */
+   EpsBearerTag (uint16_t  rnti, uint8_t bid, uint64_t imsi);
+
   /**
    * Set the RNTI to the given value.
    *


### PR DESCRIPTION
There is a EpsBearerTag (uint16_t  rnti, uint8_t bid, unint64_t imsi); initialization but the code call for EpsBearerTag (uint16_t  rnti, uint8_t bid);.
The original EpsBearerTag (uint16_t  rnti, uint8_t bid, unint64_t imsi); actually does not use imsi