### PR TITLE
create code for EpsBearerTag (uint16_t rnti, uint8_t bid);

### DIFF
--- a/model/eps-bearer-tag.cc
+++ b/model/eps-bearer-tag.cc
@@ -61,6 +61,14 @@ EpsBearerTag::EpsBearerTag ()
     m_bid (0)
 {
 }
+
+EpsBearerTag::EpsBearerTag (uint16_t rnti, uint8_t bid)
+  : m_rnti (rnti),
+    m_bid (bid)
+{
+}
+
+// This is the original initializer. It has 3 parameters but `imsi` is not used!
 EpsBearerTag::EpsBearerTag (uint16_t rnti, uint8_t bid, uint64_t imsi)
   : m_rnti (rnti),
     m_bid (bid)


### PR DESCRIPTION
There is a EpsBearerTag (uint16_t rnti, uint8_t bid, unint64_t imsi); initialization but the code call for EpsBearerTag (uint16_t rnti, uint8_t bid);. The original EpsBearerTag (uint16_t rnti, uint8_t bid, unint64_t imsi); actually does not use imsi